### PR TITLE
Make PDFiumSharp.GdiPlusV2 depend on PDFiumsSharpV2

### DIFF
--- a/Nuget/PDFiumSharp.GdiPlusV2.nuspec
+++ b/Nuget/PDFiumSharp.GdiPlusV2.nuspec
@@ -14,7 +14,7 @@
     <tags>C# PDF PDFium Renderer Rendering</tags>
     <dependencies>
       <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
-      <dependency id="PDFiumSharp" version="[1,2)" />
+      <dependency id="PDFiumSharpV2" version="[1,2)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
It currently depends on the original PDFiumSharp, which overwrites the windows DLLs that come from 
PDFium.WindowsV2.
This causes an `Unable to find an entry point named 'FPDF_LoadCustomDocument' in DLL 'pdfium_x86'` error when loading a document on x86.