### PR TITLE
Fix rendering non-form annotations

### DIFF
--- a/PDFiumSharp/PdfPage.cs
+++ b/PDFiumSharp/PdfPage.cs
@@ -89,21 +89,12 @@ namespace PDFiumSharp
 			if (renderTarget == null)
 				throw new ArgumentNullException(nameof(renderTarget));
 
-			// If we have a valid form and we were asked to render annotations
-			// we first render bitmap without annotations and render them after via a form
 			var form = this.Document.Form;
-			var renderAnnotations = !form.IsNull && flags.HasFlag(RenderingFlags.Annotations);
-			if (renderAnnotations)
-			{
-				flags &= ~RenderingFlags.Annotations;
-			}
 
 			PDFium.FPDF_RenderPageBitmap(renderTarget.Handle, this.Handle, rectDest.left, rectDest.top, rectDest.width, rectDest.height, orientation, flags);
 
-			if (renderAnnotations)
-			{
+			if (!form.IsNull && flags.HasFlag(RenderingFlags.Annotations))
 				PDFium.FPDF_FFLDraw(form, renderTarget.Handle, this.Handle, rectDest.left, rectDest.top, rectDest.width, rectDest.height, orientation, flags);
-			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Not exactly sure why it was done like this in the first place (my guess is it was assumed that `FPDF_RenderPageBitmap` and `FPDF_FFLDraw` render the exact same annotations), but according to documentation [FPDF_RenderPageBitmap](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/public/fpdfview.h#897) renders everything except widgets and popups, while [FPDF_FFLDraw](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/public/fpdf_formfill.h#1893) only renders widgets and popups. Which is why we have to pass `RenderingFlags.Annotations` flag to the both of them.